### PR TITLE
Fixed #43 CTFontCreateWithName() warning on iOS 13

### DIFF
--- a/M80AttributedLabel/M80AttributedLabel.m
+++ b/M80AttributedLabel/M80AttributedLabel.m
@@ -113,7 +113,7 @@ static NSString* const M80EllipsesCharacter = @"\u2026";
 
 - (void)resetFont
 {
-    CTFontRef fontRef = CTFontCreateWithName((CFStringRef)self.font.fontName, self.font.pointSize, NULL);
+    CTFontRef fontRef = CTFontCreateWithFontDescriptor((__bridge CTFontDescriptorRef)self.font.fontDescriptor, self.font.pointSize, NULL);
     if (fontRef)
     {
         _fontAscent     = CTFontGetAscent(fontRef);

--- a/M80AttributedLabel/NSMutableAttributedString+M80.m
+++ b/M80AttributedLabel/NSMutableAttributedString+M80.m
@@ -40,7 +40,7 @@
     {
         [self removeAttribute:(NSString*)kCTFontAttributeName range:range];
         
-        CTFontRef fontRef = CTFontCreateWithName((CFStringRef)font.fontName, font.pointSize, nil);
+        CTFontRef fontRef = CTFontCreateWithFontDescriptor((__bridge CTFontDescriptorRef)font.fontDescriptor, font.pointSize, nil);
         if (nil != fontRef)
         {
             [self addAttribute:(NSString *)kCTFontAttributeName value:(__bridge id)fontRef range:range];


### PR DESCRIPTION
Fixed #43

`CTFontCreateWithName(".SFUI-Regular")` 在 iOS 13 之前会返回 `.SFUIText-Regular` 这个字体，iOS 13 会返回 `Times New Roman` 这个字体，并且会输出警告：

```
CoreText performance note: Client called CTFontCreateWithName() using name ".SFUI-Regular" and got font with PostScript name "TimesNewRomanPSMT". For best performance, only use PostScript names when calling this API.
```

Ref from: https://github.com/Cocoanetics/DTCoreText/issues/1168#issuecomment-526411915

> This issue behaves as intended.
> As mentioned in numerous WWDC sessions, dot-prefixed font names are not to be directly used.
> I would also note that UIFont and CTFont are toll-free bridged, so they can be used interchangeably with casts.
> Please update your feedback report to let us know if this is still an issue for you.

苹果意思是不要直接使用 (.) 开头的字体名。

---

修复方案 1： 使用 `CTFontCreateWithFontDescriptor` 创建 CTFont 
修复方案 2：因为 UIFont 和 CTFont 是 toll-free bridged 的，UIFont 其实就是 CTFont，所以可以在任何需要使用 CTFont 的地方类型转换 UIFont 即可： `(__bridge CTFontRef)self.font` 


